### PR TITLE
add class Syntax Highlight

### DIFF
--- a/grammars/mermaid.cson
+++ b/grammars/mermaid.cson
@@ -125,5 +125,86 @@
     'name': 'meta.variable.mermaid'
     }
 
+    # comment
+    {
+    'match': '^\\s*@@.*$'
+    'name': 'comment'
+    }
 
+    # keyword classDiagram
+    {
+      "match": 'classDiagram'
+      'name': 'keyword.control.mermaid'
+    }
+
+    # define classname
+    {
+      "match": "(class) (\\w*)"
+      "captures": {
+        "1": {
+          "name": "keyword.control.mermaid"
+             }
+        "2": {
+          "name": "entity.name.type.class.mermaid"
+        }
+      }
+    }
+
+    # classname and colon before define member or method
+    {
+      "match": "(\\w*)\\s?(:)"
+      "captures": {
+        "1": {
+          "name": "entity.name.function.mermaid"
+        }
+        "2": {
+          "name": "punctuation.section.class.begin.mermaid"
+        }
+      }
+    }
+
+    # inheritance arrow
+    {
+      "match": "(\\w*)\\s?(<\\|--)\\s?(\\w*)"
+      "captures": {
+        "1": {
+          "name": "entity.name.function.mermaid"
+             }
+        "2": {
+          "name": "keyword.operator.math.mermaid"
+             }
+        "3": {
+          "name": "entity.name.function.mermaid"
+        }
+      }
+    }
+
+    # member
+    {
+      "match": "(\\+|-)(\\w*)\\s(\\w*)"
+      "captures": {
+        "1": {
+          "name": "keyword.operator.math.mermaid"
+        }
+        "2": {
+          "name": "keyword.type.mermaid"
+        }
+        "3": {
+          "name": "variable"
+        }
+      }
+    }
+
+    # method
+    {
+      "match": "(\\+|-)(\\w*\\(\\))"
+      "captures": {
+        "1": {
+          "name": "keyword.operator.math.mermaid"
+        }
+        "2": {
+          "name": "string"
+        }
+      }
+    }
 ]


### PR DESCRIPTION
Hello ytisf!

I had the opportunity to use mermaid in Atom today and decided to use it mainly for creating UML diagrams.
However, it is inconvenient as it is, so I tried writing SyntaxHighlight only in the simple part of the class. My personal request is, if you like, can you merge? I want to write mermaid with Atom comfortably!

It works good!(this is screen shot on my Atom.)
![image](https://user-images.githubusercontent.com/44631106/79040850-744c9980-7c26-11ea-9749-c0724e152293.png)
