### PR TITLE
Gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cson linguist-detectable=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+/grammars/* linguist-documentation=true
+/settings/* linguist-documentation=true
 *.cson linguist-detectable=true


### PR DESCRIPTION
This allows [Linguist](https://github.com/github/linguist) to see .cson files as code instead of documentation. Languages should show up in the side bar.